### PR TITLE
Clean action codes

### DIFF
--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -35,7 +35,8 @@ SELECT
 
   (
     SELECT json_agg(json_build_object(
-      'dcp_name', SUBSTRING(a.dcp_name FROM '-{1}(.*)'), -- use regex to pull out action name -{1}(.*)
+      'dcp_name', SUBSTRING(a.dcp_name FROM '-{1}\s*(.*)'), -- use regex to pull out action name -{1}(.*)
+      'actioncode', SUBSTRING(a.dcp_name FROM '^(\w+)'),
       'dcp_ulurpnumber', a.dcp_ulurpnumber,
       'dcp_prefix', a.dcp_prefix,
       'statuscode', a.statuscode

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -32,9 +32,10 @@ SELECT
     FROM dcp_projectbbl b
     WHERE b.dcp_project = p.dcp_projectid
   ) AS bbls,
+
   (
     SELECT json_agg(json_build_object(
-      'dcp_name', a.dcp_name,
+      'dcp_name', SUBSTRING(a.dcp_name FROM '-{1}(.*)'), -- use regex to pull out action name -{1}(.*)
       'dcp_ulurpnumber', a.dcp_ulurpnumber,
       'dcp_prefix', a.dcp_prefix,
       'statuscode', a.statuscode
@@ -43,6 +44,7 @@ SELECT
     WHERE a.dcp_project = p.dcp_projectid
       AND a.statuscode <> 'Mistake'
   ) AS actions,
+
   (
     SELECT json_agg(json_build_object(
       'dcp_name', m.dcp_name,

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -39,9 +39,12 @@ SELECT
       'actioncode', SUBSTRING(a.dcp_name FROM '^(\w+)'),
       'dcp_ulurpnumber', a.dcp_ulurpnumber,
       'dcp_prefix', a.dcp_prefix,
-      'statuscode', a.statuscode
+      'statuscode', a.statuscode,
+      'dcp_ccresolutionnumber', a.dcp_ccresolutionnumber,
+      'dcp_zoningresolution', z.dcp_zoningresolution
     ))
     FROM dcp_projectaction a
+    LEFT JOIN dcp_zoningresolution z ON a.dcp_zoningresolution = z.dcp_zoningresolutionid
     WHERE a.dcp_project = p.dcp_projectid
       AND a.statuscode <> 'Mistake'
   ) AS actions,


### PR DESCRIPTION
- Adds SQL join for looking up the zoning resolution string from table `dcp_zoningresolution`
- Splits `action.dcp_name` into two fields
   - `dcp-name` the human-readable string for the action type.
  - `actioncode` the abbreviated code for the action type (ZR, ZM, etc) which is used in the frontend for looking up tooltips, etc