### PR TITLE
Refine queries

### DIFF
--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -10,6 +10,6 @@ WHERE dcp_validatedcommunitydistricts ILIKE '%${communityDistrict:value}%'
   AND coalesce(dcp_publicstatus, 'Unknown') IN (${dcp_publicstatus:csv})
   AND coalesce(dcp_ceqrtype, 'Unknown') IN (${dcp_ceqrtype:csv})
   AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
-  AND dcp_publicstatus IS NOT NULL -- Anything with a null public status is excluded
+  AND dcp_visibility = 'General Public'
 ORDER BY dcp_name DESC
 ${paginate^}

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -86,10 +86,10 @@ SELECT
       'Community Board Referral',
       'Borough President Referral',
       'Borough Board Referral',
-      'CPC Public Meeting – Vote',
+      'CPC Public Meeting - Vote',
       'CPC Public Meeting - Public Hearing',
       'City Council Review',
-      'Mayoral Vote',
+      'Mayoral Veto',
       'Final Letter Sent'
     )
   ) AS milestones,

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -111,4 +111,4 @@ SELECT
 FROM dcp_project p
 LEFT JOIN account ON p.dcp_applicant_customer = account.accountid
 WHERE dcp_name = '${id:value}'
-  AND dcp_publicstatus IS NOT NULL
+  AND dcp_visibility = 'General Public'


### PR DESCRIPTION
This PR adds three important changes to the SQL queries.
- Limits both `index` and `show` SQL to only show projects where `dcp_publicstatus` is non-null.  (The app will only show projects that have one of the four public statuses.

- Limits the milestones that show for a project to those that are linked to the lead action.

- Adds a list of public milestones to further limit milestone results.