### PR TITLE
Add fema param

### DIFF
--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -1,15 +1,24 @@
-SELECT 
+SELECT
   dcp_name,
   dcp_projectname,
   dcp_projectbrief,
+  dcp_publicstatus,
   dcp_certifiedreferred,
   dcp_projectid,
+  dcp_femafloodzonea,
+  dcp_femafloodzonecoastala,
+  dcp_femafloodzoneshadedx,
+  dcp_femafloodzonev,
   cast(count(dcp_projectid) OVER() as integer) as total_projects
 FROM dcp_project p
 WHERE coalesce(dcp_publicstatus, 'Unknown') IN (${dcp_publicstatus:csv})
   AND coalesce(dcp_ceqrtype, 'Unknown') IN (${dcp_ceqrtype:csv})
   AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
   AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
+  ${dcp_femafloodzoneaQuery^}
+  ${dcp_femafloodzonecoastalaQuery^}
+  ${dcp_femafloodzoneshadedxQuery^}
+  ${dcp_femafloodzonevQuery^}
   AND dcp_visibility = 'General Public'
   ${communityDistrictsQuery^}
 ORDER BY dcp_name DESC

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -10,6 +10,6 @@ WHERE dcp_validatedcommunitydistricts ILIKE '%${communityDistrict:value}%'
   AND coalesce(dcp_publicstatus, 'Unknown') IN (${dcp_publicstatus:csv})
   AND coalesce(dcp_ceqrtype, 'Unknown') IN (${dcp_ceqrtype:csv})
   AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
-  AND dcp_publicstatus IS NOT NULL -- Anything with a null public status is excluded
+  AND dcp_visibility = 'General Public'
 ORDER BY dcp_name DESC
 ${paginate^}

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -86,10 +86,10 @@ SELECT
       'Community Board Referral',
       'Borough President Referral',
       'Borough Board Referral',
-      'CPC Public Meeting – Vote',
+      'CPC Public Meeting - Vote',
       'CPC Public Meeting - Public Hearing',
       'City Council Review',
-      'Mayoral Vote',
+      'Mayoral Veto',
       'Final Letter Sent'
     )
   ) AS milestones,

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -111,4 +111,4 @@ SELECT
 FROM dcp_project p
 LEFT JOIN account ON p.dcp_applicant_customer = account.accountid
 WHERE dcp_name = '${id:value}'
-  AND dcp_publicstatus IS NOT NULL
+  AND dcp_visibility = 'General Public'

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -45,10 +45,10 @@ router.get('/', async (req, res) => {
       dcp_publicstatus = ['Approved', 'Withdrawn', 'Filed', 'Certified', 'Unknown'],
       dcp_ceqrtype = ['Type I', 'Type II', 'Unlisted', 'Unknown'],
       dcp_ulurp_nonulurp = ['ULURP', 'Non-ULURP'],
-      // dcp_femafloodzonea = false,
-      // dcp_femafloodzonecoastala = false,
-      // dcp_femafloodzoneshadedx = false,
-      // dcp_femafloodzonev = false,
+      dcp_femafloodzonea = false,
+      dcp_femafloodzonecoastala = false,
+      dcp_femafloodzoneshadedx = false,
+      dcp_femafloodzonev = false,
     },
   } = req;
 
@@ -56,12 +56,23 @@ router.get('/', async (req, res) => {
   const communityDistrictsQuery =
     communityDistricts[0] ? pgp.as.format('AND dcp_validatedcommunitydistricts ilike any (array[$1:csv])', [communityDistricts.map(district => `%${district}%`)]) : '';
 
+  // special handling for FEMA flood zones
+  // to only filter when set to true
+  const dcp_femafloodzoneaQuery = dcp_femafloodzonea ? 'AND dcp_femafloodzonea = true' : '';
+  const dcp_femafloodzonecoastalaQuery = dcp_femafloodzonecoastala ? 'AND dcp_femafloodzonecoastala = true' : '';
+  const dcp_femafloodzoneshadedxQuery = dcp_femafloodzoneshadedx ? 'AND dcp_femafloodzoneshadedx = true' : '';
+  const dcp_femafloodzonevQuery = dcp_femafloodzonev ? 'AND dcp_femafloodzonev = true' : '';
+
   try {
     const projects =
       await db.any(listProjectsQuery, {
         dcp_publicstatus,
         dcp_ceqrtype,
         dcp_ulurp_nonulurp,
+        dcp_femafloodzoneaQuery,
+        dcp_femafloodzonecoastalaQuery,
+        dcp_femafloodzoneshadedxQuery,
+        dcp_femafloodzonevQuery,
         communityDistrictsQuery,
         paginate,
       });


### PR DESCRIPTION
Adds query params for the 4 types of flood zones.  

The api only expects to see flood zone params set to true.  Adds an `AND` to the WHERE clause for each flood zone passed in as `true`.