### PR TITLE
cache query instead of projectids list, optimize vector tile query

### DIFF
--- a/queries/helpers/bounding-box-query.sql
+++ b/queries/helpers/bounding-box-query.sql
@@ -12,8 +12,6 @@ ARRAY[
 FROM (
   SELECT ST_Extent(geom) AS bbox
   FROM (
-    SELECT geom
-    FROM project_centroids
-    WHERE projectid IN (${tileProjects:csv})
+    ${tileQuery^}
   ) x
 ) y

--- a/queries/helpers/generate-vector-tile.sql
+++ b/queries/helpers/generate-vector-tile.sql
@@ -1,18 +1,18 @@
+WITH tilebounds (geom) AS (SELECT ST_MakeEnvelope($1, $2, $3, $4, 4326))
 SELECT ST_AsMVT(q, 'project-centroids', 4096, 'geom')
 FROM (
   SELECT
-      c.projectid,
-      p.dcp_projectname,
-      ST_AsMVTGeom(
-          geom,
-          ST_MakeEnvelope($1, $2, $3, $4, 4326),
-          4096,
-          256,
-          false
-      ) geom
-  FROM project_centroids c
-  LEFT JOIN dcp_project p
-    ON c.projectid = p.dcp_name
-  WHERE ST_Intersects(ST_SetSRID(geom, 4326), ST_MakeEnvelope($1, $2, $3, $4, 4326))
-  AND projectid IN ($5:csv)
+    projectid,
+    dcp_projectname,
+    ST_AsMVTGeom(
+      x.geom,
+      tileBounds.geom,
+      4096,
+      256,
+      false
+    ) geom
+  FROM (
+    $5^
+  ) x, tilebounds
+  WHERE ST_Intersects(x.geom, tilebounds.geom)
 ) q

--- a/queries/helpers/standard-projects-columns.sql
+++ b/queries/helpers/standard-projects-columns.sql
@@ -1,4 +1,4 @@
-,
+dcp_name,
 dcp_projectname,
 dcp_projectbrief,
 dcp_publicstatus_simp,

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -9,7 +9,6 @@ WITH normalized_projects AS (
 )
 
 SELECT
-  dcp_name
   ${standardColumns^}
 FROM normalized_projects p
 LEFT JOIN project_centroids c

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -90,7 +90,7 @@ router.get('/', async (req, res) => {
 
     // if this is the first page of a new query, include bounds for the query's geoms, and a vector tile template
     let tileMeta = {};
-    if (page === '1') {
+    if (page === 1) {
       // tileQuery is uses the same WHERE clauses as above,
       // but only SELECTs geom, projectid, and projectname, and does not include pagination
 
@@ -108,13 +108,11 @@ router.get('/', async (req, res) => {
       });
 
       // get the bounds for the geometries
-      let bounds;
+      // default to a bbox for the whole city
+      let bounds = [[-74.2553345639348, 40.498580711525], [-73.7074928813077, 40.9141778017518]];
       if (total) {
         bounds = await db.one(boundingBoxQuery, { tileQuery });
         bounds = bounds.bbox;
-      } else {
-        // default view for no results should be the whole city
-        bounds = [[-74.2553345639348, 40.498580711525], [-73.7074928813077, 40.9141778017518]];
       }
 
       // create a shortid for this query and store it in the cache


### PR DESCRIPTION
This PR Improves the efficiency of the bounding box and vector tile queries:
- the `tileid` in the vector tile route now references the original query, not a list of projectids.  This avoids the very long `WHERE projectid IN (...)` queries that we were using before in the vector tiles
- the `tileid` query  is only cached and the bounds are only calculated if `page === 1`, so we are not wasting resources making duplicative tilesets on subsequent pages of the same query.
- the vector tile query itself now uses a Common Table Expression for calculating the tile bound geometry using `ST_MakeEnvelope()`.  This allows postGIS to take advantage of the spatial index on `project_centroids`, reducing tile generation for the full 28k projects query from ~17 seconds to ~1 second!
