### PR TITLE
119 borough filter

### DIFF
--- a/queries/helpers/standard-projects-columns.sql
+++ b/queries/helpers/standard-projects-columns.sql
@@ -16,10 +16,4 @@ dcp_femafloodzonev,
 dcp_applicant,
 cast(count(dcp_projectid) OVER() as integer) as total_projects,
 CASE WHEN c.geom IS NOT NULL THEN true ELSE false END AS has_centroid,
-(
-  SELECT ARRAY_AGG(a.dcp_ulurpnumber)
-  FROM dcp_projectaction a
-  WHERE a.dcp_project = p.dcp_projectid
-    AND a.statuscode <> 'Mistake'
-    AND a.dcp_ulurpnumber IS NOT NULL
-) AS ulurpnumbers
+string_to_array(ulurpnumbers, ';') as ulurpnumbers

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -13,6 +13,7 @@ WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   ${dcp_femafloodzoneaQuery^}
   ${dcp_femafloodzoneshadedxQuery^}
   ${communityDistrictsQuery^}
+  ${boroughsQuery^}
   ${actionTypesQuery^}
   ${textQuery^}
 ORDER BY dcp_name DESC

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -16,5 +16,6 @@ WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   ${boroughsQuery^}
   ${actionTypesQuery^}
   ${textQuery^}
+  ${blockQuery^}
 ORDER BY dcp_name DESC
 ${paginate^}

--- a/queries/projects/normalized-projects.sql
+++ b/queries/projects/normalized-projects.sql
@@ -9,7 +9,8 @@ CREATE MATERIALIZED VIEW normalized_projects AS
       WHEN dcp_project.dcp_publicstatus = 'Certified' THEN 'In Public Review'
       ELSE dcp_project.dcp_publicstatus
     END AS dcp_publicstatus_simp,
-    STRING_AGG(SUBSTRING(dcp_projectaction.dcp_name FROM '^(\w+)'), ';') AS actiontypes
+    STRING_AGG(SUBSTRING(dcp_projectaction.dcp_name FROM '^(\w+)'), ';') AS actiontypes,
+    STRING_AGG(dcp_projectaction.dcp_ulurpnumber, ';') AS ulurpnumbers
   FROM dcp_project
   LEFT JOIN account
     ON dcp_project.dcp_applicant_customer = account.accountid

--- a/queries/projects/normalized-projects.sql
+++ b/queries/projects/normalized-projects.sql
@@ -10,11 +10,14 @@ CREATE MATERIALIZED VIEW normalized_projects AS
       ELSE dcp_project.dcp_publicstatus
     END AS dcp_publicstatus_simp,
     STRING_AGG(SUBSTRING(dcp_projectaction.dcp_name FROM '^(\w+)'), ';') AS actiontypes,
-    STRING_AGG(dcp_projectaction.dcp_ulurpnumber, ';') AS ulurpnumbers
+    STRING_AGG(dcp_projectaction.dcp_ulurpnumber, ';') AS ulurpnumbers,
+    STRING_AGG(dcp_projectbbl.dcp_validatedblock, ';') AS blocks
   FROM dcp_project
   LEFT JOIN account
     ON dcp_project.dcp_applicant_customer = account.accountid
   INNER JOIN dcp_projectaction
     ON dcp_projectaction.dcp_project = dcp_project.dcp_projectid
+  INNER JOIN dcp_projectbbl
+    ON dcp_projectbbl.dcp_project = dcp_project.dcp_projectid
   WHERE dcp_projectaction.statuscode <> 'Mistake'
   GROUP BY dcp_project.dcp_projectid, account.name, dcp_project.dcp_publicstatus

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -79,7 +79,7 @@ router.get('/', async (req, res) => {
   const dcp_femafloodzonecoastalaQuery = dcp_femafloodzonecoastala === 'true' ? 'AND dcp_femafloodzonecoastala = true' : '';
   const dcp_femafloodzoneaQuery = dcp_femafloodzonea === 'true' ? 'AND dcp_femafloodzonea = true' : '';
   const dcp_femafloodzoneshadedxQuery = dcp_femafloodzoneshadedx === 'true' ? 'AND dcp_femafloodzoneshadedx = true' : '';
-  const textQuery = text_query ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (dcp_applicant ilike '%$1:value%'))", [text_query]) : '';
+  const textQuery = text_query ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (dcp_applicant ilike '%$1:value%') OR (ulurpnumbers ilike '%$1:value%'))", [text_query]) : '';
 
 
   try {

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -53,6 +53,7 @@ router.get('/', async (req, res) => {
       // filters
       'community-districts': communityDistricts = [],
       'action-types': actionTypes = [],
+      boroughs = [],
       dcp_ceqrtype = ['Type I', 'Type II', 'Unlisted', 'Unknown'],
       dcp_ulurp_nonulurp = ['ULURP', 'Non-ULURP'],
       dcp_femafloodzonev = false,
@@ -67,6 +68,8 @@ router.get('/', async (req, res) => {
   const paginate = generateDynamicQuery(paginateQuery, { itemsPerPage, offset: (page - 1) * itemsPerPage });
   const communityDistrictsQuery =
     communityDistricts[0] ? pgp.as.format('AND dcp_validatedcommunitydistricts ilike any (array[$1:csv])', [communityDistricts.map(district => `%${district}%`)]) : '';
+
+  const boroughsQuery = boroughs[0] ? pgp.as.format('AND dcp_borough ilike any (array[$1:csv])', [boroughs.map(borough => `%${borough}%`)]) : '';
 
   const actionTypesQuery = actionTypes[0] ? pgp.as.format('AND actiontypes ilike any (array[$1:csv])', [actionTypes.map(actionType => `%${actionType}%`)]) : '';
 
@@ -91,6 +94,7 @@ router.get('/', async (req, res) => {
         dcp_femafloodzoneaQuery,
         dcp_femafloodzoneshadedxQuery,
         communityDistrictsQuery,
+        boroughsQuery,
         actionTypesQuery,
         textQuery,
         paginate,
@@ -116,6 +120,7 @@ router.get('/', async (req, res) => {
         dcp_femafloodzoneaQuery,
         dcp_femafloodzoneshadedxQuery,
         communityDistrictsQuery,
+        boroughsQuery,
         actionTypesQuery,
         textQuery,
         paginate: '',

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -62,6 +62,7 @@ router.get('/', async (req, res) => {
       dcp_femafloodzoneshadedx = false,
       dcp_publicstatus = ['Complete', 'Filed', 'In Public Review', 'Unknown'],
       text_query = '',
+      block = '',
     },
   } = req;
 
@@ -80,7 +81,7 @@ router.get('/', async (req, res) => {
   const dcp_femafloodzoneaQuery = dcp_femafloodzonea === 'true' ? 'AND dcp_femafloodzonea = true' : '';
   const dcp_femafloodzoneshadedxQuery = dcp_femafloodzoneshadedx === 'true' ? 'AND dcp_femafloodzoneshadedx = true' : '';
   const textQuery = text_query ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (dcp_applicant ilike '%$1:value%') OR (ulurpnumbers ilike '%$1:value%'))", [text_query]) : '';
-
+  const blockQuery = block ? pgp.as.format("AND (blocks ilike '%$1:value%')", [block]) : '';
 
   try {
     const projects =
@@ -97,6 +98,7 @@ router.get('/', async (req, res) => {
         boroughsQuery,
         actionTypesQuery,
         textQuery,
+        blockQuery,
         paginate,
       });
 
@@ -123,6 +125,7 @@ router.get('/', async (req, res) => {
         boroughsQuery,
         actionTypesQuery,
         textQuery,
+        blockQuery,
         paginate: '',
       });
 


### PR DESCRIPTION
Adds several new query params:

`boroughs` (array) Array of capitalized borough names or "Citywide"
`block` (string) a block text string to match against the  new `blocks` column

Updates queries to add `ulurpnumbers` and  `blocks` as semicolon-delimited text columns for easy searching.
Updates `text-query` param to also compare to `ulurpnumbers`  (formerly only compared project name, applicant name, project brief)