### PR TITLE
Applicant teams

### DIFF
--- a/queries/helpers/standard-projects-columns.sql
+++ b/queries/helpers/standard-projects-columns.sql
@@ -12,7 +12,7 @@ dcp_femafloodzonea,
 dcp_femafloodzonecoastala,
 dcp_femafloodzoneshadedx,
 dcp_femafloodzonev,
-dcp_applicant,
+applicants,
 cast(count(dcp_projectid) OVER() as integer) as total_projects,
 CASE WHEN c.geom IS NOT NULL THEN true ELSE false END AS has_centroid,
 string_to_array(ulurpnumbers, ';') as ulurpnumbers

--- a/queries/projects/normalized-projects.sql
+++ b/queries/projects/normalized-projects.sql
@@ -103,6 +103,7 @@ LEFT JOIN (
   LEFT JOIN account
 	ON account.accountid = pa.dcp_applicant_customer
   WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+  AND pa.statuscode = 'Active'
   ORDER BY dcp_applicantrole ASC
 ) applicantteams
   ON applicantteams.dcp_project = dcp_project.dcp_projectid

--- a/queries/projects/normalized-projects.sql
+++ b/queries/projects/normalized-projects.sql
@@ -1,102 +1,109 @@
 -- this is the base query used for filtering
 
 CREATE MATERIALIZED VIEW normalized_projects AS
-  SELECT dcp_project.*,
-    coalesce(account.name, 'Unknown Applicant') AS dcp_applicant,
-    CASE
-      WHEN dcp_project.dcp_publicstatus = 'Filed' THEN 'Filed'
-      WHEN dcp_project.dcp_publicstatus = 'Certified' THEN 'In Public Review'
-      WHEN dcp_project.dcp_publicstatus = 'Approved' THEN 'Complete'
-      WHEN dcp_project.dcp_publicstatus = 'Withdrawn' THEN 'Complete'
-      ELSE 'Unknown'
-    END AS dcp_publicstatus_simp,
-    STRING_AGG(SUBSTRING(actions.dcp_name FROM '^(\w+)'), ';') AS actiontypes,
-    STRING_AGG(DISTINCT actions.dcp_ulurpnumber, ';') AS ulurpnumbers,
-    STRING_AGG(dcp_projectbbl.dcp_validatedblock, ';') AS blocks
-  FROM dcp_project
-  LEFT JOIN account
-    ON dcp_project.dcp_applicant_customer = account.accountid
-  LEFT JOIN (
-    SELECT * FROM dcp_projectaction
-    WHERE statuscode <> 'Mistake'
-    AND SUBSTRING(dcp_name FROM '^(\w+)') IN (
-      'BD',
-      'BF',
-      'CM',
-      'CP',
-      'DL',
-      'DM',
-      'EB',
-      'EC',
-      'EE',
-      'EF',
-      'EM',
-      'EN',
-      'EU',
-      'GF',
-      'HA',
-      'HC',
-      'HD',
-      'HF',
-      'HG',
-      'HI',
-      'HK',
-      'HL',
-      'HM',
-      'HN',
-      'HO',
-      'HP',
-      'HR',
-      'HS',
-      'HU',
-      'HZ',
-      'LD',
-      'MA',
-      'MC',
-      'MD',
-      'ME',
-      'MF',
-      'ML',
-      'MM',
-      'MP',
-      'MY',
-      'NP',
-      'PA',
-      'PC',
-      'PD',
-      'PE',
-      'PI',
-      'PL',
-      'PM',
-      'PN',
-      'PO',
-      'PP',
-      'PQ',
-      'PR',
-      'PS',
-      'PX',
-      'RA',
-      'RC',
-      'RS',
-      'SC',
-      'TC',
-      'TL',
-      'UC',
-      'VT',
-      'ZA',
-      'ZC',
-      'ZD',
-      'ZJ',
-      'ZL',
-      'ZM',
-      'ZP',
-      'ZR',
-      'ZS',
-      'ZX',
-      'ZZ'
-    )
-  ) actions
+SELECT dcp_project.*,
+  CASE
+    WHEN dcp_project.dcp_publicstatus = 'Filed' THEN 'Filed'
+    WHEN dcp_project.dcp_publicstatus = 'Certified' THEN 'In Public Review'
+    WHEN dcp_project.dcp_publicstatus = 'Approved' THEN 'Complete'
+    WHEN dcp_project.dcp_publicstatus = 'Withdrawn' THEN 'Complete'
+    ELSE 'Unknown'
+  END AS dcp_publicstatus_simp,
+  STRING_AGG(SUBSTRING(actions.dcp_name FROM '^(\w+)'), ';') AS actiontypes,
+  STRING_AGG(DISTINCT actions.dcp_ulurpnumber, ';') AS ulurpnumbers,
+  STRING_AGG(dcp_projectbbl.dcp_validatedblock, ';') AS blocks,
+  STRING_AGG(applicantteams.name, ';') AS applicants
+FROM dcp_project
+LEFT JOIN (
+  SELECT * FROM dcp_projectaction
+  WHERE statuscode <> 'Mistake'
+  AND SUBSTRING(dcp_name FROM '^(\w+)') IN (
+    'BD',
+    'BF',
+    'CM',
+    'CP',
+    'DL',
+    'DM',
+    'EB',
+    'EC',
+    'EE',
+    'EF',
+    'EM',
+    'EN',
+    'EU',
+    'GF',
+    'HA',
+    'HC',
+    'HD',
+    'HF',
+    'HG',
+    'HI',
+    'HK',
+    'HL',
+    'HM',
+    'HN',
+    'HO',
+    'HP',
+    'HR',
+    'HS',
+    'HU',
+    'HZ',
+    'LD',
+    'MA',
+    'MC',
+    'MD',
+    'ME',
+    'MF',
+    'ML',
+    'MM',
+    'MP',
+    'MY',
+    'NP',
+    'PA',
+    'PC',
+    'PD',
+    'PE',
+    'PI',
+    'PL',
+    'PM',
+    'PN',
+    'PO',
+    'PP',
+    'PQ',
+    'PR',
+    'PS',
+    'PX',
+    'RA',
+    'RC',
+    'RS',
+    'SC',
+    'TC',
+    'TL',
+    'UC',
+    'VT',
+    'ZA',
+    'ZC',
+    'ZD',
+    'ZJ',
+    'ZL',
+    'ZM',
+    'ZP',
+    'ZR',
+    'ZS',
+    'ZX',
+    'ZZ'
+  )
+) actions
   ON actions.dcp_project = dcp_project.dcp_projectid
-  LEFT JOIN dcp_projectbbl
-    ON dcp_projectbbl.dcp_project = dcp_project.dcp_projectid
-  GROUP BY dcp_project.dcp_projectid, account.name, dcp_project.dcp_publicstatus
+LEFT JOIN dcp_projectbbl
+  ON dcp_projectbbl.dcp_project = dcp_project.dcp_projectid
+LEFT JOIN (
+  SELECT dcp_project, CASE WHEN pa.dcp_name IS NOT NULL THEN pa.dcp_name ELSE account.name END as name
+  FROM dcp_projectapplicant pa
+  LEFT JOIN account
+	ON account.accountid = pa.dcp_applicant_customer
+  WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+  ORDER BY dcp_applicantrole ASC
+) applicantteams
+  ON applicantteams.dcp_project = dcp_project.dcp_projectid
+GROUP BY dcp_project.dcp_projectid, dcp_project.dcp_publicstatus

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -35,7 +35,7 @@ SELECT
     SELECT json_agg(b.dcp_bblnumber)
     FROM dcp_projectbbl b
     WHERE b.dcp_project = p.dcp_projectid
-    AND b.dcp_bblnumber IS NOT NULL
+    AND b.dcp_bblnumber IS NOT NULL AND statuscode = 'Active'
   ) AS bbls,
 
   (
@@ -207,7 +207,7 @@ SELECT
     ))
     FROM dcp_projectaddress a
     WHERE a.dcp_project = p.dcp_projectid
-      AND (dcp_validatedaddressnumber IS NOT NULL AND dcp_validatedstreet IS NOT NULL)
+      AND (dcp_validatedaddressnumber IS NOT NULL AND dcp_validatedstreet IS NOT NULL AND statuscode = 'Active')
   ) AS addresses
 FROM dcp_project p
 WHERE dcp_name = '${id:value}'

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -195,6 +195,7 @@ SELECT
       FROM dcp_projectapplicant
       WHERE dcp_project = p.dcp_projectid
         AND dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+        AND statuscode = 'Active'
       ORDER BY dcp_applicantrole ASC
     ) pa
     LEFT JOIN account

--- a/routes/projects/tiles.js
+++ b/routes/projects/tiles.js
@@ -22,7 +22,6 @@ router.get('/:tileId/:z/:x/:y.mvt', async (req, res) => {
 
   // retreive the projectids from the cache
   const tileQuery = await app.tileCache.get(tileId);
-  console.log('tileQuery', tileQuery);
   // calculate the bounding box for this tile
   const bbox = mercator.bbox(x, y, z, false);
 

--- a/utils/build-projects-sql.js
+++ b/utils/build-projects-sql.js
@@ -43,7 +43,7 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
     communityDistricts[0] ? pgp.as.format('AND dcp_validatedcommunitydistricts ilike any (array[$1:csv])', [communityDistricts.map(district => `%${district}%`)]) : '';
   const boroughsQuery = boroughs[0] ? pgp.as.format('AND dcp_borough ilike any (array[$1:csv])', [boroughs.map(borough => `%${borough}%`)]) : '';
   const actionTypesQuery = actionTypes[0] ? pgp.as.format('AND actiontypes ilike any (array[$1:csv])', [actionTypes.map(actionType => `%${actionType}%`)]) : '';
-  const projectApplicantTextQuery = project_applicant_text ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (dcp_applicant ilike '%$1:value%'))", [project_applicant_text]) : '';
+  const projectApplicantTextQuery = project_applicant_text ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (applicants ilike '%$1:value%'))", [project_applicant_text]) : '';
   const ulurpCeqrQuery = ulurp_ceqr_text ? pgp.as.format("AND ((ulurpnumbers ILIKE '%$1:value%') OR dcp_ceqrnumber ILIKE '%$1:value%')", [ulurp_ceqr_text]) : '';
   const blockQuery = block ? pgp.as.format("AND (blocks ilike '%$1:value%')", [block]) : '';
   const paginate = generateDynamicQuery(paginateQuery, { itemsPerPage, offset: (page - 1) * itemsPerPage });


### PR DESCRIPTION
Adds multiple applicant types to a project.

In the filter query, `applicants` is a comma-delimited string of applicant names.
In the project query, `applicantteam` is an array of objects, each with `role` and `name`.