### PR TITLE
add ceqr endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // import routes
 app.use('/projects', require('./routes/projects'));
+app.use('/ceqr', require('./routes/ceqr'));
 app.use('/zap', require('./routes/zap'));
 app.use('/export', require('./routes/export'));
 

--- a/routes/ceqr.js
+++ b/routes/ceqr.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const carto = require('../utils/carto');
+
+const router = express.Router();
+
+router.get('/:ceqrnumber', async (req, res) => {
+  const { ceqrnumber } = req.params;
+
+  const SQL = `SELECT url FROM ceqrview_projects WHERE ceqr_number IN ('${ceqrnumber}')`;
+
+  try {
+    const [data] = await carto.SQL(SQL);
+    const { url } = data;
+
+    res.redirect(301, url);
+  } catch (error) {
+    res.redirect(301, 'https://a002-ceqraccess.nyc.gov/ceqr/');
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Adds a ceqr endpoint:

`/ceqr/:ceqrnumber` checks `ceqrnumber` against a lookup table in carto.

If found, return a 301 and redirect to the corresponding ceqr access page.
If not found, return a 301 and redirect to the ceqr access search page.

This is temporary until the Mayor's Office of Environmental Coordination publishes the project urls on NYC Open Data.