### PR TITLE
Ceqr and ulurp redirect urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ Use query Parameters for filtering:
 
 Used by the frontend to get JSON data for a single project.  Example:`/projects/2018K0356`
 
-`GET /zap/:zapAcronym` - Get projects for a community district
-
-Used by the [Community Profiles](https://communityprofiles.planning.nyc.gov/) site to list ZAP projects for a given community district.
-
 `GET /projects/tiles/:tileid/:z/:x/:y.mvt` - Get a vector tile for the
 
 `GET /projects/:ceqrnumber` - A redirect query to make predictable URLs for zap projects using only a ceqr number.  if the ceqr number matches a project, returns a 301 redirect to the project page.  If the ceqr number cannot be found, returns a 301 redirect to the project filter page.
+
+`GET /projects/:ulurpnumber` - A redirect query to make predictable URLs for zap projects using only a ulurp number.  if the ulurp number matches a project, returns a 301 redirect to the project page.  If the ulurp number cannot be found, returns a 301 redirect to the project filter page.
+
+
+`GET /zap/:zapAcronym` - Get projects for a community district
+
+Used by the [Community Profiles](https://communityprofiles.planning.nyc.gov/) site to list ZAP projects for a given community district.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ Used by the frontend to get JSON data for a single project.  Example:`/projects/
 
 `GET /zap/:zapAcronym` - Get projects for a community district
 
-Used by the [Community Profiles](https://communityprofiles.planning.nyc.gov/) site to list ZAP projects for a given community distric.
+Used by the [Community Profiles](https://communityprofiles.planning.nyc.gov/) site to list ZAP projects for a given community district.
 
-`GET /projects/tiles/:tileid/:z/:x/:y.mvt` - Get a vector tile for the  
+`GET /projects/tiles/:tileid/:z/:x/:y.mvt` - Get a vector tile for the
+
+`GET /projects/:ceqrnumber` - A redirect query to make predictable URLs for zap projects using only a ceqr number.  if the ceqr number matches a project, returns a 301 redirect to the project page.  If the ceqr number cannot be found, returns a 301 redirect to the project filter page.
 
 ## Deployment
 

--- a/routes/projects/ceqr.js
+++ b/routes/projects/ceqr.js
@@ -1,0 +1,31 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/:ceqrnumber', async (req, res) => {
+  const { app, params } = req;
+  const { ceqrnumber } = params;
+  // find projectid for this ceqrnumber
+  // http://localhost:3000/projects/ceqr/18DCP155K
+
+  const SQL = `SELECT dcp_name as projectid FROM dcp_project WHERE dcp_ceqrnumber LIKE '${ceqrnumber}'`;
+
+  // ceqrnumber should be 6-10 capital letters, numbers, and hyphens
+  if (ceqrnumber.match(/^[0-9A-Z-]{6,10}$/)) {
+    try {
+      const { projectid } = await app.db.one(SQL);
+      const url = `https://zap.planning.nyc.gov/projects/${projectid}`;
+
+      res.redirect(301, url);
+    } catch (error) {
+      res.redirect(301, 'https://a002-ceqraccess.nyc.gov/ceqr/');
+    }
+  } else {
+    res.status(422).send({
+      error: 'Invalid input',
+    });
+  }
+});
+
+
+module.exports = router;

--- a/routes/projects/index.js
+++ b/routes/projects/index.js
@@ -17,6 +17,7 @@ router.use('/:id', require('./project'));
 router.use('/slack', require('./slack'));
 router.use('/tiles', require('./tiles'));
 router.use('/ceqr', require('./ceqr'));
+router.use('/ulurp', require('./ulurp'));
 
 const boundingBoxQuery = getQueryFile('helpers/bounding-box-query.sql');
 

--- a/routes/projects/index.js
+++ b/routes/projects/index.js
@@ -16,6 +16,7 @@ router.use('/feedback', require('./feedback'));
 router.use('/:id', require('./project'));
 router.use('/slack', require('./slack'));
 router.use('/tiles', require('./tiles'));
+router.use('/ceqr', require('./ceqr'));
 
 const boundingBoxQuery = getQueryFile('helpers/bounding-box-query.sql');
 

--- a/routes/projects/ulurp.js
+++ b/routes/projects/ulurp.js
@@ -1,0 +1,30 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/:ulurpnumber', async (req, res) => {
+  const { app, params } = req;
+  const { ulurpnumber } = params;
+  // find projectid for this ceqrnumber
+  // http://localhost:3000/projects/ulurp/170358ZMM
+
+  const SQL = `SELECT dcp_name as projectid FROM normalized_projects WHERE ulurpnumbers ILIKE '%${ulurpnumber}%'`;
+
+  // ulurpnumber should be 6-10 capital letters, numbers, and hyphens
+  if (ulurpnumber.match(/^[0-9A-Za-z]{4,12}$/)) {
+    try {
+      const { projectid } = await app.db.one(SQL);
+      const url = `https://zap.planning.nyc.gov/projects/${projectid}`;
+
+      res.redirect(301, url);
+    } catch (error) {
+      res.redirect(301, 'https://zap.planning.nyc.gov/projects');
+    }
+  } else {
+    res.status(422).send({
+      error: 'Invalid input',
+    });
+  }
+});
+
+module.exports = router;

--- a/utils/carto.js
+++ b/utils/carto.js
@@ -3,16 +3,30 @@ const fetch = require('node-fetch');
 const cartoUsername = 'planninglabs';
 const cartoDomain = `${cartoUsername}.carto.com`;
 
-const buildSqlUrl = function(cleanedQuery, type = 'json') { // eslint-disable-line
-  return `https://${cartoDomain}/api/v2/sql?q=${cleanedQuery}&format=${type}`;
+const buildSqlUrl = (cleanedQuery, format = 'json', method) => { // eslint-disable-line
+  let url = `https://${cartoUsername}.carto.com/api/v2/sql`;
+  url += method === 'get' ? `?q=${cleanedQuery}&format=${format}` : '';
+  return url;
 };
 
 const carto = {
-  SQL(query, type = 'json') {
+  SQL(query, format = 'json', method = 'get') {
     const cleanedQuery = query.replace('\n', '');
-    const url = buildSqlUrl(cleanedQuery, type);
+    const url = buildSqlUrl(cleanedQuery, format, method);
 
-    return fetch(url)
+    let fetchOptions = {};
+
+    if (method === 'post') {
+      fetchOptions = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        },
+        body: `q=${cleanedQuery}&format=${format}`,
+      };
+    }
+
+    return fetch(url, fetchOptions)
       .then((response) => {
         if (response.ok) {
           return response.json();
@@ -20,7 +34,7 @@ const carto = {
         throw new Error('Not found');
       })
       .then((d) => { // eslint-disable-line
-        return type === 'json' ? d.rows : d;
+        return format === 'json' ? d.rows : d;
       });
   },
 };

--- a/utils/get-bbl-feature-collection.js
+++ b/utils/get-bbl-feature-collection.js
@@ -12,7 +12,7 @@ function getBblFeatureCollection(bbls) {
     WHERE bbl IN (${mutatedBBLs.join(',')})
   `;
 
-  return carto.SQL(SQL, 'geojson');
+  return carto.SQL(SQL, 'geojson', 'post');
 }
 
 module.exports = getBblFeatureCollection;


### PR DESCRIPTION
Adds a `GET /projects/ceqr/:ceqrnumber` route, which will redirect to a project page (if the ceqrnumber is found) or to the filter page ( if it is not found).

Adds a `GET /projects/ulurp/:ulurp` route, which does the same for a ulurp number

This is useful for allowing an app that has ceqr or ulurp numbers to build URLs to link to ZAP projects (like ZoLa)

