### PR TITLE
use webmercator for vector tile query

### DIFF
--- a/queries/helpers/generate-vector-tile.sql
+++ b/queries/helpers/generate-vector-tile.sql
@@ -1,4 +1,4 @@
-WITH tilebounds (geom) AS (SELECT ST_MakeEnvelope($1, $2, $3, $4, 4326))
+WITH tilebounds (geom) AS (SELECT ST_MakeEnvelope($1, $2, $3, $4, 3857))
 SELECT ST_AsMVT(q, 'project-centroids', 4096, 'geom')
 FROM (
   SELECT
@@ -6,7 +6,7 @@ FROM (
     dcp_projectname,
     dcp_publicstatus_simp,
     ST_AsMVTGeom(
-      x.geom,
+      ST_Transform(x.geom, 3857),
       tileBounds.geom,
       4096,
       256,
@@ -15,7 +15,7 @@ FROM (
   FROM (
     $5^
   ) x, tilebounds
-  WHERE ST_Intersects(x.geom, tilebounds.geom)
+  WHERE ST_Transform(x.geom, 3857) && tilebounds.geom
   ORDER BY CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1
                 WHEN dcp_publicstatus_simp = 'Filed' then 2
                 WHEN dcp_publicstatus_simp = 'Completed' then 3

--- a/routes/projects/tiles.js
+++ b/routes/projects/tiles.js
@@ -23,7 +23,7 @@ router.get('/:tileId/:z/:x/:y.mvt', async (req, res) => {
   // retreive the projectids from the cache
   const tileQuery = await app.tileCache.get(tileId);
   // calculate the bounding box for this tile
-  const bbox = mercator.bbox(x, y, z, false);
+  const bbox = mercator.bbox(x, y, z, false, '900913');
 
   try {
     const tile = await app.db.one(generateVectorTile, [...bbox, tileQuery]);


### PR DESCRIPTION
This PR makes a small change to the way the `/tiles` endpoint generates vector tiles.

Before, we were getting a WGS84 bounding box for a tile using `sphericalmercator` in node, then using those bounds to find the intersecting geometries.  

This was causing a subtle shift in the point rendering when moving between zoom levels, (when zoomed  out the points were all shifted north, not showing in the correct place)

Now it uses a webmercator bounding box, and transforms the all geometries to webmercator to find the intersecting features.