### PR TITLE
filter deactivated keywords in Project Details

### DIFF
--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -181,7 +181,7 @@ SELECT
     SELECT json_agg(dcp_keyword.dcp_keyword)
     FROM dcp_projectkeywords k
     LEFT JOIN dcp_keyword ON k.dcp_keyword = dcp_keyword.dcp_keywordid
-    WHERE k.dcp_project = p.dcp_projectid
+    WHERE k.dcp_project = p.dcp_projectid and k.statuscode ='Active'
   ) AS keywords,
   (
     SELECT json_agg(


### PR DESCRIPTION
Bug fix submission to remove deactivated keywords from showing in set of keywords in project details 

 Public facing results for 270 Park Ave at https://zap.planning.nyc.gov/projects/P2018M0307 has an incorrect keyword (POPS), which has been removed on internal version, but it is still showing in ZAP Search.