### PR TITLE
use-aliased-data

### DIFF
--- a/utils/upsert-geoms.js
+++ b/utils/upsert-geoms.js
@@ -52,7 +52,7 @@ const getProjectGeoms = async (bbls) => {
       ST_Multi(ST_Union(the_geom)) AS polygons,
       ST_Centroid(ST_Union(the_geom)) AS centroid,
       version AS mappluto_v
-    FROM mappluto_18v2
+    FROM mappluto
     WHERE bbl IN (${collectedBBLs.join(',')})
     GROUP BY version
   `;


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to NYCPlanning/labs-layers-api#124