### PR TITLE
hotfix, move queryFile gettr outside of route handler

### DIFF
--- a/routes/projects/project.js
+++ b/routes/projects/project.js
@@ -5,15 +5,14 @@ const normalizeSupportDocs = require('../../utils/inject-supporting-document-url
 
 const router = express.Router({ mergeParams: true });
 
+// import sql query templates
+const findProjectQuery = getQueryFile('/projects/show.sql');
 
 /* GET /projects/:id */
 /* Retreive a single project */
 router.get('/', async (req, res) => {
   const { app, params } = req;
   const { id } = params;
-
-  // import sql query templates
-  const findProjectQuery = getQueryFile('/projects/show.sql');
 
   try {
     const project = await app.db.one(findProjectQuery, { id });


### PR DESCRIPTION
Maybe related to #58, moves a `getQueryFile()` call to outside of the route handler so it is only called once and won't be called on every request.