### PR TITLE
412: deduplicate action types and add ceqr type to CSV download

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.16.3",
     "express-recaptcha": "^4.0.2",
     "fast-csv": "^2.4.1",
+    "json-stream-stringify": "^2.0.1",
     "json2csv": "^4.1.5",
     "moment": "^2.22.2",
     "morgan": "^1.9.0",

--- a/queries/helpers/standard-projects-columns.sql
+++ b/queries/helpers/standard-projects-columns.sql
@@ -1,5 +1,6 @@
 dcp_name,
 dcp_ceqrnumber,
+dcp_ceqrtype,
 dcp_projectname,
 dcp_projectbrief,
 dcp_publicstatus_simp,

--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -6,7 +6,6 @@ LEFT JOIN project_geoms c
 WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   AND coalesce(dcp_ceqrtype, 'Unknown') IN (${dcp_ceqrtype:csv})
   AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
-  AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
   AND dcp_visibility = 'General Public'
   ${dcp_femafloodzonevQuery^}
   ${dcp_femafloodzonecoastalaQuery^}

--- a/routes/projects/download.js
+++ b/routes/projects/download.js
@@ -2,6 +2,7 @@ const express = require('express');
 const Json2csvTransform = require('json2csv').Transform;
 const QueryStream = require('pg-query-stream');
 const JSONStream = require('JSONStream');
+const { Transform } = require('stream');
 const buildProjectsSQL = require('../../utils/build-projects-sql');
 
 
@@ -26,6 +27,21 @@ router.get('/', async (req, res) => {
     const transformOpts = { highWaterMark: 16384, encoding: 'utf-8' };
     const json2csv = new Json2csvTransform({}, transformOpts);
 
+    // deduplicates actiontypes for objects in an object stream
+    const dedupeActions = new Transform({
+      objectMode: true,
+
+      transform(chunk, encoding, callback) {
+        if (chunk.actiontypes) {
+          const { actiontypes } = chunk;
+          const typesArray = actiontypes.split(';');
+          const dedupedTypesArray = [...new Set(typesArray)];
+          chunk.actiontypes = dedupedTypesArray.join(';');
+        }
+        callback(null, chunk);
+      },
+    });
+
     // Set approrpiate download headers
     res.setHeader('Content-disposition', 'attachment; filename=projects.csv');
     res.writeHead(200, { 'Content-Type': 'text/csv' });
@@ -35,7 +51,8 @@ router.get('/', async (req, res) => {
 
     app.db.stream(qs, (s) => {
       // initiate streaming into the console:
-      s.pipe(JSONStream.stringify()).pipe(json2csv).pipe(res);
+      // objects are transformed (dedupeActions), then serialized from JSON, then converted to CSV before being returned
+      s.pipe(dedupeActions).pipe(JSONStream.stringify()).pipe(json2csv).pipe(res);
     })
       .then((data) => {
         console.log( // eslint-disable-line

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+json-stream-stringify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-2.0.1.tgz#8bc0e65ff94567d9010e14c27c043a951cb14939"
+  integrity sha512-5XymtJXPmzRWZ1UdLQQQXbjHV/E7NAanSClikEqORbkZKOYLSYLNHqRuooyju9W90kJUzknFhX2xvWn4cHluHQ==
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"


### PR DESCRIPTION
- add action `dedupeActions` to `download` route to deduplicate action types from CSV download
- add `dcp_ceqrtype` to `standardcolumns` so that it's included in download query

Closes [#412](https://github.com/NYCPlanning/labs-zap-search/issues/412) & [#305](https://github.com/NYCPlanning/labs-zap-search/issues/305) in zap-search issues