### PR TITLE
474 optimize spatial intersection

### DIFF
--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -18,7 +18,7 @@ WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   ${actionTypesQuery^}
   ${projectApplicantTextQuery^}
   ${ulurpCeqrQuery^}
-  ${radiusQuery^}
+  ${radiusDistanceQuery^}
   ${blockQuery^}
 ORDER BY lastmilestonedate DESC NULLS LAST,
 CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1

--- a/utils/build-projects-sql.js
+++ b/utils/build-projects-sql.js
@@ -47,7 +47,31 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
   const projectApplicantTextQuery = project_applicant_text ? pgp.as.format("AND ((dcp_projectbrief ilike '%$1:value%') OR (dcp_projectname ilike '%$1:value%') OR (applicants ilike '%$1:value%'))", [project_applicant_text]) : '';
   const ulurpCeqrQuery = ulurp_ceqr_text ? pgp.as.format("AND ((ulurpnumbers ILIKE '%$1:value%') OR dcp_ceqrnumber ILIKE '%$1:value%')", [ulurp_ceqr_text]) : '';
   const blockQuery = block ? pgp.as.format("AND (blocks ilike '%$1:value%')", [block]) : '';
-  const radiusQuery = distance_from_point[0] ? pgp.as.format('AND ST_Distance_Sphere(c.polygons, ST_MakePoint($1,$2)) <= $3', [...distance_from_point, ((radius_from_point / 5280) * 1609.34)]) : '';
+
+  /**
+   * radiusDistanceQuery is the query for our radius distance filter --> in the frontend, a user can click
+   * a point on the map and filter for all projects located within a distance from that point. When a user
+   * creates this point with a click event, query parameters are changed. When query parameters are changed,
+   * fetchData occurs. The distance_from_point (the coordinates) and radius_from_point (the distance) values
+   * are sent to the backend. The backend then performs the filtering with this query.
+   *
+   * -  ST_DWithin queries all geometries within the specified distance from a point, with the 1st parameter
+   *    being the origin point, the 2nd parameter being the geometries to query based on the input distance,
+   *    and the 3rd parameter being the distance
+   * -  in pgp.as.format the 1st parameter is the query, the 2nd parameter is the values (which take the place
+   *     of $1, $2, and $3 here)
+   * -  $1 and $2 are the coordinates of the point (distance_from_point)
+   * -  $3 is the distance from the point (radius_from_point)
+   * -  ::geography converts the value from geometry data type to geography data type (geography data type
+   *    should be used if you have points that are more than a mile apart)
+   * -  the radius_from_point value is set in the frontend as feet, we convert it to meters to run this query
+   */
+
+  const METERS_TO_FEET_FACTOR = 3.28084;
+
+  const radiusDistanceQuery = distance_from_point[0] ? pgp.as.format('AND ST_DWithin(ST_MakePoint($1,$2)::geography, c.polygons::geography, $3)', [...distance_from_point, (radius_from_point / METERS_TO_FEET_FACTOR)]) : '';
+
+
   const paginate = generateDynamicQuery(paginateQuery, { itemsPerPage, offset: (page - 1) * itemsPerPage });
 
   if (type === 'filter') {
@@ -67,7 +91,7 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
       projectApplicantTextQuery,
       ulurpCeqrQuery,
       blockQuery,
-      radiusQuery,
+      radiusDistanceQuery,
       paginate,
     });
   }
@@ -89,7 +113,7 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
       projectApplicantTextQuery,
       ulurpCeqrQuery,
       blockQuery,
-      radiusQuery,
+      radiusDistanceQuery,
       paginate: '',
     });
   }
@@ -111,7 +135,7 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
       projectApplicantTextQuery,
       ulurpCeqrQuery,
       blockQuery,
-      radiusQuery,
+      radiusDistanceQuery,
       paginate: '',
     });
   }


### PR DESCRIPTION
This PR is meant to speed up the spatial querying that we use for our radius distance filter, where a user creates a point on the map and projects are filtered for a distance from that point. 

- changed `radiusDistanceQuery` to use `ST_DWithin` which queries for all geometries within a distance from a point, this query receives a `distance_from_point` value (the coordinates) and a `radius_from_point` value (the distance) from the frontend, then filtering is performed in the backend
- Also part of this PR was adding indexes on both the `centroid` and `polygons` geometry columns in table `project_geoms`

Indexes were created with:

`CREATE INDEX centroid_index ON project_geoms USING gist(centroid);`
`CREATE INDEX polygons_index ON project_geoms USING gist(polygons);`

Closes [#474](https://github.com/NYCPlanning/labs-zap-search/issues/474)