### PR TITLE
501: use project id array in tiles WHERE clause

### DIFF
--- a/queries/helpers/bounding-box-query.sql
+++ b/queries/helpers/bounding-box-query.sql
@@ -10,8 +10,9 @@ ARRAY[
   ]
 ] as bbox
 FROM (
-  SELECT ST_Extent(centroid) AS bbox
+  ---now that we're using column centroid_3857 for our tiles, we need to transform it here to EPSG 4326---
+  SELECT ST_Extent(ST_Transform(centroid_3857, 4326)) AS bbox
   FROM (
-    ${tileQuery^}
+    ${tileSQL^}
   ) x
 ) y

--- a/queries/helpers/generate-vector-tile.sql
+++ b/queries/helpers/generate-vector-tile.sql
@@ -7,7 +7,7 @@ FROM (
     dcp_publicstatus_simp,
     lastmilestonedate,
     ST_AsMVTGeom(
-      ST_Transform(x.$6^, 3857),
+      x.$6^,
       tileBounds.geom,
       4096,
       256,
@@ -16,7 +16,7 @@ FROM (
   FROM (
     $5^
   ) x, tilebounds
-  WHERE ST_Transform(x.$6^, 3857) && tilebounds.geom
+  WHERE x.$6^ && tilebounds.geom
   ORDER BY CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1
                 WHEN dcp_publicstatus_simp = 'Filed' then 2
                 WHEN dcp_publicstatus_simp = 'Completed' then 3

--- a/queries/helpers/tile-query.sql
+++ b/queries/helpers/tile-query.sql
@@ -1,0 +1,5 @@
+SELECT centroid_3857, polygons_3857, projectid, dcp_projectname, dcp_publicstatus_simp,lastmilestonedate
+FROM normalized_projects p
+LEFT JOIN project_geoms c
+  ON p.dcp_name = c.projectid
+WHERE dcp_name IN (${projectIds^})

--- a/routes/projects/index.js
+++ b/routes/projects/index.js
@@ -1,3 +1,4 @@
+const pgp = require('pg-promise');
 const express = require('express');
 const turfBbox = require('@turf/bbox');
 const turfBuffer = require('@turf/buffer');
@@ -23,6 +24,8 @@ router.use('/ulurp', require('./ulurp'));
 
 const boundingBoxQuery = getQueryFile('helpers/bounding-box-query.sql');
 
+const tileQuery = getQueryFile('helpers/tile-query.sql');
+
 /* GET /projects */
 /* gets a JSON array of projects that match the query params */
 router.get('/', async (req, res) => {
@@ -40,7 +43,20 @@ router.get('/', async (req, res) => {
     let tileMeta = {};
     const { page } = query;
     if (page === '1') {
-      const tileQuery = buildProjectsSQL(query, 'tiles');
+      // extract projectId strings from projectId object array
+      let projectIds = await app.db.any(buildProjectsSQL(query, 'projectids'));
+      projectIds = projectIds.map(d => d.projectid);
+      // we extract projectIds query to enable a one-time generation of projectIds that meet the filter requirements
+      // these projectId strings then get injected into the tile query--which is cached
+      // this speeds up tile generation because the original query WHERE clause that found matching projectIds
+      // no longer needs to run on every tile query
+      // instead, it only runs once for a given filter set, and is then cached
+
+      // pass a list of projectids (strings) into tileQuery
+      // we then use node cache later to cache this SQL query with app.tileCache.set
+      const tileSQL = pgp.as.format(tileQuery, {
+        projectIds: projectIds.map(d => `'${d}'`).join(','),
+      });
 
       // create array of projects that have geometry
       const projectsWithGeometries = projects.filter(project => project.has_centroid);
@@ -51,7 +67,7 @@ router.get('/', async (req, res) => {
       let bounds = [[-74.2553345639348, 40.498580711525], [-73.7074928813077, 40.9141778017518]];
 
       if (projectsWithGeometries.length > 0) {
-        bounds = await app.db.one(boundingBoxQuery, { tileQuery });
+        bounds = await app.db.one(boundingBoxQuery, { tileSQL });
         bounds = bounds.bbox;
       }
 
@@ -76,7 +92,9 @@ router.get('/', async (req, res) => {
 
       // create a shortid for this query and store it in the cache
       const tileId = shortid.generate();
-      await app.tileCache.set(tileId, tileQuery);
+      // tileSQL is just tileQuery with a list of projectid strings passed into it
+      // here we use node-cache to store SQL queries -- myCache.set( key, val )
+      await app.tileCache.set(tileId, tileSQL);
 
       tileMeta = {
         tiles: [`${process.env.HOST}/projects/tiles/${tileId}/{z}/{x}/{y}.mvt`],

--- a/routes/projects/tiles.js
+++ b/routes/projects/tiles.js
@@ -26,8 +26,10 @@ router.get('/:tileId/:z/:x/:y.mvt', async (req, res) => {
   // calculate the bounding box for this tile
   const bbox = mercator.bbox(x, y, z, false, '900913');
 
+  const geomColumn = (type === 'centroid') ? 'centroid_3857' : 'polygons_3857';
+
   try {
-    const tile = await app.db.one(generateVectorTile, [...bbox, tileQuery, type]);
+    const tile = await app.db.one(generateVectorTile, [...bbox, tileQuery, geomColumn]);
 
     res.setHeader('Content-Type', 'application/x-protobuf');
 

--- a/scripts/update-all-geoms.js
+++ b/scripts/update-all-geoms.js
@@ -30,7 +30,7 @@ const getProjectsSQL = `
 
   let i = 0;
   const updateGeoms = async () => {
-    const apiUrl = `http://localhost:3000/projects/update-geometries/${projects[i]}`;
+    const apiUrl = `http://localhost:${process.env.PORT}/projects/update-geometries/${projects[i]}`;
     const status = await fetch(apiUrl)
       .then(d => d.json())
       .catch(() => {

--- a/utils/build-projects-sql.js
+++ b/utils/build-projects-sql.js
@@ -93,9 +93,10 @@ const buildProjectsSQL = (queryParams, type = 'filter') => {
     });
   }
 
-  if (type === 'tiles') {
+  // returns only projectids that match the query params, without pagination
+  if (type === 'projectids') {
     return pgp.as.format(listProjectsQuery, {
-      standardColumns: 'centroid, polygons, projectid, dcp_projectname, dcp_publicstatus_simp,lastmilestonedate',
+      standardColumns: 'projectid',
       dcp_publicstatus,
       dcp_ceqrtype,
       dcp_ulurp_nonulurp,


### PR DESCRIPTION
- In this PR we are storing the project IDs associated with the filtering query in a list of strings
- query type `projectids` in `buildProjectsSQL` generates a list of Project IDs
- We then run `tileQuery` with this ID list in the WHERE clause
- We store this SQL query using node-cache (`app.tileCache.set(tileId, tileSQL`). 

- Before we were storing the fully query we used to generate the projects list, and we were using the same query as a subquery to generate tiles. Now we just store an array of projectIds which makes the tiles query go from ~1 second to ~0.2 seconds. Now a user can move around the map without changing the query. 

Closes [#501](https://github.com/NYCPlanning/labs-zap-search/issues/501)

