### PR TITLE
515: re-add ulurp/nonulurp filter

### DIFF
--- a/queries/projects/index.sql
+++ b/queries/projects/index.sql
@@ -4,6 +4,7 @@ FROM normalized_projects p
 LEFT JOIN project_geoms c
   ON p.dcp_name = c.projectid
 WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
+  AND coalesce(dcp_ulurp_nonulurp, 'Unknown') IN (${dcp_ulurp_nonulurp:csv})
   AND dcp_visibility = 'General Public'
   ${dcp_femafloodzonevQuery^}
   ${dcp_femafloodzonecoastalaQuery^}


### PR DESCRIPTION
Re-add ulurp_nonulurp filter on index.sql

Merge this before PR [#516](https://github.com/NYCPlanning/labs-zap-search/pull/516) in zap-search

Closes [#515](https://github.com/NYCPlanning/labs-zap-search/issues/515)