### PR TITLE
No supporting docs if no actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
       - run: yarn test
 
       # deploy
+      - run:
+          name: Avoid hosts unknown for github
+          command: ssh-keyscan planninglabs.nyc >> ~/.ssh/known_hosts
       - deploy:
           name: Deployment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       # deploy
       - run:
           name: Avoid hosts unknown for github
-          command: ssh-keyscan planninglabs.nyc >> ~/.ssh/known_hosts
+          command: mkdir ~/.ssh && touch ~/.ssh/known_hosts && ssh-keyscan zap-api.planninglabs.nyc >> ~/.ssh/known_hosts
       - deploy:
           name: Deployment
           command: |

--- a/utils/inject-supporting-document-urls.js
+++ b/utils/inject-supporting-document-urls.js
@@ -14,52 +14,54 @@ const MILESTONE_TYPES = {
 
 async function injectSupportDocumentURLs(project) {
   // extract trimmed ULURP number
-  const ulurpNumbers = project.actions
-    .filter(({ dcp_ulurpnumber }) => dcp_ulurpnumber) // filter out nulls
-    .map(({ dcp_ulurpnumber }) => dcp_ulurpnumber.match(/[A-Z]?([A-Z0-9]{6,7})[A-Z]{3}/))
-    .map(ulurpNumber => (ulurpNumber || [])[1]);
+  if (project.actions) {
+    const ulurpNumbers = project.actions
+      .filter(({ dcp_ulurpnumber }) => dcp_ulurpnumber) // filter out nulls
+      .map(({ dcp_ulurpnumber }) => dcp_ulurpnumber.match(/[A-Z]?([A-Z0-9]{6,7})[A-Z]{3}/))
+      .map(ulurpNumber => (ulurpNumber || [])[1]);
 
-  // hit s3 object listing for all ULURP number & doc-type combination
-  const searchResults = await Promise.all([
-    ...ulurpNumbers
-      .map(ulurlp => fetch(`${S3_BUCKET_HOST}/?prefix=comments/${ulurlp}`)
-        .then(blob => blob.text())
-        .then(text => parseStringAsync(text))),
-    ...ulurpNumbers
-      .map(ulurlp => fetch(`${S3_BUCKET_HOST}/?prefix=letters-dob-hpd/${ulurlp}`)
-        .then(blob => blob.text())
-        .then(text => parseStringAsync(text))),
-  ]);
+    // hit s3 object listing for all ULURP number & doc-type combination
+    const searchResults = await Promise.all([
+      ...ulurpNumbers
+        .map(ulurlp => fetch(`${S3_BUCKET_HOST}/?prefix=comments/${ulurlp}`)
+          .then(blob => blob.text())
+          .then(text => parseStringAsync(text))),
+      ...ulurpNumbers
+        .map(ulurlp => fetch(`${S3_BUCKET_HOST}/?prefix=letters-dob-hpd/${ulurlp}`)
+          .then(blob => blob.text())
+          .then(text => parseStringAsync(text))),
+    ]);
 
-  // extract relevant contents, filter undefineds, and flatten
-  const allSupportingDocs = searchResults
-    .map(result => result['ListBucketResult']['Contents']) // eslint-disable-line
-    .filter(Boolean)
-    .reduce((acc, curr) => acc.concat(curr), []);
+    // extract relevant contents, filter undefineds, and flatten
+    const allSupportingDocs = searchResults
+      .map(result => result['ListBucketResult']['Contents']) // eslint-disable-line
+      .filter(Boolean)
+      .reduce((acc, curr) => acc.concat(curr), []);
 
-  project.milestones.forEach((milestone) => {
-    const { milestonename } = milestone;
-    const regex = MILESTONE_TYPES[milestonename];
+    project.milestones.forEach((milestone) => {
+      const { milestonename } = milestone;
+      const regex = MILESTONE_TYPES[milestonename];
 
-    if (regex) {
-      const foundDocuments = allSupportingDocs.filter(({ Key: key }) => {
-        const [filename] = key;
+      if (regex) {
+        const foundDocuments = allSupportingDocs.filter(({ Key: key }) => {
+          const [filename] = key;
 
-        return filename.match(regex);
-      });
-
-      if (foundDocuments.length) {
-        milestone.milestoneLinks = foundDocuments.map((doc) => {
-          const { Key: [filename] } = doc;
-
-          return {
-            filename: filename.split('/')[1],
-            url: `${S3_BUCKET_HOST}/${filename}`,
-          };
+          return filename.match(regex);
         });
+
+        if (foundDocuments.length) {
+          milestone.milestoneLinks = foundDocuments.map((doc) => {
+            const { Key: [filename] } = doc;
+
+            return {
+              filename: filename.split('/')[1],
+              url: `${S3_BUCKET_HOST}/${filename}`,
+            };
+          });
+        }
       }
-    }
-  });
+    });
+  }
 }
 
 module.exports = injectSupportDocumentURLs;


### PR DESCRIPTION
If a project does not have any actions, do not inject a supporting document. 

This was originally causing an Error, because a new project had no Actions and the utility was still running on that project, breaking things. 