### PR TITLE
If project has no action, don't add support docs, caused error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,12 @@ jobs:
       - run: yarn test
 
       # deploy
+<<<<<<< HEAD
       - run:
           name: Avoid hosts unknown for github
           command: ssh-keyscan zap-api.planninglabs.nyc >> ~/.ssh/known_hosts
+=======
+>>>>>>> parent of dfe0068... update known hosts for circlCI
       - deploy:
           name: Deployment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
       - run: yarn test
 
       # deploy
+      - run:
+          name: Avoid hosts unknown for github
+          command: ssh-keyscan planninglabs.nyc >> ~/.ssh/known_hosts
       - deploy:
           name: Deployment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       # deploy
       - run:
           name: Avoid hosts unknown for github
-          command: ssh-keyscan planninglabs.nyc >> ~/.ssh/known_hosts
+          command: mkdir ~/.ssh && touch ~/.ssh/known_hosts && ssh-keyscan zap-api.planninglabs.nyc >> ~/.ssh/known_hosts
       - deploy:
           name: Deployment
           command: |

--- a/utils/inject-supporting-document-urls.js
+++ b/utils/inject-supporting-document-urls.js
@@ -13,6 +13,11 @@ const MILESTONE_TYPES = {
 };
 
 async function injectSupportDocumentURLs(project) {
+// only projects with actions have supporting documents
+  if (!project.actions) {
+    return;
+  }
+
   // extract trimmed ULURP number
   const ulurpNumbers = project.actions
     .filter(({ dcp_ulurpnumber }) => dcp_ulurpnumber) // filter out nulls

--- a/utils/inject-supporting-document-urls.js
+++ b/utils/inject-supporting-document-urls.js
@@ -13,6 +13,10 @@ const MILESTONE_TYPES = {
 };
 
 async function injectSupportDocumentURLs(project) {
+  // only projects with actions have supporting documents
+  if (!project.actions) {
+    return;
+  }
   // extract trimmed ULURP number
   const ulurpNumbers = project.actions
     .filter(({ dcp_ulurpnumber }) => dcp_ulurpnumber) // filter out nulls


### PR DESCRIPTION
This PR makes it so that the behavior in the utility `inject-supporting-document-urls` only occurs if a project HAS actions.

Before, this behavior was running on a project that did not have actions and was breaking the project page. 

I just wrapped this behavior in the utility in an if statement:

`if (project.actions) {`