### PR TITLE
If project has no actions, do not add support docs

### DIFF
--- a/utils/inject-supporting-document-urls.js
+++ b/utils/inject-supporting-document-urls.js
@@ -13,6 +13,11 @@ const MILESTONE_TYPES = {
 };
 
 async function injectSupportDocumentURLs(project) {
+  // only projects with actions have supporting documents
+  if (!project.actions) {
+    return;
+  }
+
   // extract trimmed ULURP number
   const ulurpNumbers = project.actions
     .filter(({ dcp_ulurpnumber }) => dcp_ulurpnumber) // filter out nulls


### PR DESCRIPTION
This PR makes it so that the behavior in the utility inject-supporting-document-urls only occurs if a project HAS actions.

Before, this behavior was running on a project that did not have actions and was breaking the project page.
