### PR TITLE
195: add disposition attributes for displaying hearing & rec buttons

### DIFF
--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -341,7 +341,22 @@ SELECT
     FROM dcp_projectaddress a
     WHERE a.dcp_project = p.dcp_projectid
       AND (dcp_validatedaddressnumber IS NOT NULL AND dcp_validatedstreet IS NOT NULL AND statuscode = 'Active')
-  ) AS addresses
+  ) AS addresses,
+  (
+    SELECT json_agg(
+      json_build_object(
+        'recommendationsubmittedby', disp.dcp_recommendationsubmittedby,
+        'representing', disp.dcp_representing,
+        'dateofpublichearing', disp.dcp_dateofpublichearing,
+        'boroughboardrecommendation', disp.dcp_boroughboardrecommendation,
+        'communityboardrecommendation', disp.dcp_communityboardrecommendation,
+        'boroughpresidentrecommendation', disp.dcp_boroughpresidentrecommendation
+      )
+    )
+    FROM dcp_communityboarddisposition AS disp
+    WHERE
+      disp.dcp_project = p.dcp_projectid
+  ) AS lup_dispositions
 FROM dcp_project p
 WHERE dcp_name = '${id:value}'
   AND dcp_visibility = 'General Public'


### PR DESCRIPTION
This PR adds a lup_dispositions json blob query to project/show.sql. These attributes are necessary for the implementation of https://github.com/NYCPlanning/labs-zap-search/issues/660.

Notes on related implementation in the front-end:
- The front-end will know the user's `contactid`. The hearing and rec buttons on the project profile should only show up if the logged in user's `contactid` is equal to the `recommendationsubmittedby` returned in the lup_dispositions json object in this API response.
- The hearing button should be enabled if any of the `dateofpublichearing` values are NULL.
- Depending on the `representing` value in the lup_dispositions json object, the front-end should check to see if the corresponding `boroughboardrecommendation`, `communityboardrecommendation`, or `boroughpresidentrecommendation` values are NULL. If any of the role's rec values are NULL AND the hearing values are not NULL, the recommendation button should be enabled.

Addresses #195 