### PR TITLE
177: show deis hearings before certification

### DIFF
--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -195,7 +195,7 @@ SELECT
           WHEN mm.dcp_milestone = 'a43beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualenddate
           WHEN mm.dcp_milestone = '863beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualenddate
           WHEN mm.dcp_milestone = '7c3beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualstartdate
-          WHEN mm.dcp_milestone = '7e3beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualenddate
+          WHEN mm.dcp_milestone = '7e3beec4-dad0-e711-8116-1458d04e2fb8' THEN mm.dcp_actualenddate
           WHEN mm.dcp_milestone = '883beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualstartdate
           WHEN mm.dcp_milestone = '783beec4-dad0-e711-8116-1458d04e2fb8' THEN mm.dcp_actualstartdate
           WHEN mm.dcp_milestone = 'aa3beec4-dad0-e711-8116-1458d04e2fb8' AND p.dcp_publicstatus <> 'Filed' THEN mm.dcp_actualenddate


### PR DESCRIPTION
This is a quick hotfix to fix the logic for displaying DEIS Scoping Meeting dates. These meetings almost always occur before a project certifies, and the previous logic was incorrectly hiding the dates until the project certified. 

I've confirmed the corrected display with LUR on a high priority project that has been getting questions about the missing milestone dates.