### PR TITLE
144: fix geom creation issue

### DIFF
--- a/routes/projects/update-geometries.js
+++ b/routes/projects/update-geometries.js
@@ -27,7 +27,7 @@ router.get('/', async (req, res) => {
           response,
         });
       } catch (e) {
-        console.log('Error updating geometries', error); // eslint-disable-line
+        console.log('Error updating geometries', e); // eslint-disable-line
         res.status(500).send({ error: e.toString() });
       }
     }

--- a/test/integration/routes.projects.update-geometries.test.js
+++ b/test/integration/routes.projects.update-geometries.test.js
@@ -10,10 +10,12 @@ chai.use(chaiHttp);
 const server = require('../../app');
 // const upsertGeoms = require('../../utils/upsert-geoms');
 
+const { USER_API_KEY } = process.env;
+
 describe('update-geometries route', () => {
   it('should respond with failure if id does not meet regex requirements', (done) => {
     chai.request(server)
-      .get('/projects/update-geometries/P201RQ0293')
+      .get(`/projects/update-geometries/P201RQ0293?API_KEY=${USER_API_KEY}`)
       .end((err, res) => {
         should.not.exist(err);
         res.status.should.equal(200);
@@ -27,7 +29,7 @@ describe('update-geometries route', () => {
 
   it('should respond failure message if project does not have BBLs', (done) => {
     chai.request(server)
-      .get('/projects/update-geometries/P1984Y0176')
+      .get(`/projects/update-geometries/P1984Y0176?API_KEY=${USER_API_KEY}`)
       .end((err, res) => {
         should.not.exist(err);
         res.status.should.equal(200);
@@ -42,7 +44,7 @@ describe('update-geometries route', () => {
 
   it('should respond success message if project is updated', (done) => {
     chai.request(server)
-      .get('/projects/update-geometries/P2017M0085')
+      .get(`/projects/update-geometries/P2017M0085?API_KEY=${USER_API_KEY}`)
       .end((err, res) => {
         should.not.exist(err);
         res.status.should.equal(200);

--- a/utils/upsert-geoms.js
+++ b/utils/upsert-geoms.js
@@ -15,12 +15,14 @@ const matchBBLSQL = `
 
 // SQL template, upsert command to insert rows that don't exist and update rows that do exist
 const upsertSQL = `
-  INSERT INTO project_geoms(projectid, polygons, centroid, mappluto_v)
+  INSERT INTO project_geoms(projectid, polygons, centroid, polygons_3857, centroid_3857, mappluto_v)
   VALUES
     (
     \${id},
     \${polygons},
     \${centroid},
+    \${polygons_3857},
+    \${centroid_3857},
     \${mappluto_v}
     )
   ON CONFLICT (projectid)
@@ -29,6 +31,8 @@ const upsertSQL = `
       SET
         polygons = \${polygons},
         centroid = \${centroid},
+        polygons_3857 = \${polygons_3857},
+        centroid_3857 = \${centroid_3857},
         mappluto_v = \${mappluto_v};
 `;
 
@@ -51,6 +55,8 @@ const getProjectGeoms = async (bbls) => {
     SELECT
       ST_Multi(ST_Union(the_geom)) AS polygons,
       ST_Centroid(ST_Union(the_geom)) AS centroid,
+      ST_Multi(ST_Union(the_geom_webmercator)) AS polygons_3857,
+      ST_Centroid(ST_Union(the_geom_webmercator)) AS centroid_3857,
       version AS mappluto_v
     FROM mappluto
     WHERE bbl IN (${collectedBBLs.join(',')})
@@ -62,6 +68,8 @@ const getProjectGeoms = async (bbls) => {
     return {
       polygons: null,
       centroid: null,
+      polygons_3857: null,
+      centroid_3857: null,
       mappluto_v: null,
     };
   }
@@ -80,7 +88,13 @@ async function upsertGeoms(id, db) {
     };
   }
 
-  const { polygons, centroid, mappluto_v } = await getProjectGeoms(bbls); // get geoms from carto that match array of bbls
+  const {
+    polygons,
+    centroid,
+    polygons_3857,
+    centroid_3857,
+    mappluto_v,
+  } = await getProjectGeoms(bbls); // get geoms from carto that match array of bbls
 
   if (polygons == null) {
     return {
@@ -94,6 +108,8 @@ async function upsertGeoms(id, db) {
     id,
     polygons,
     centroid,
+    polygons_3857,
+    centroid_3857,
     mappluto_v,
   });
 


### PR DESCRIPTION
For the past two months, our API has been failing to write geometry data to the `project_geoms` table. This has been happening because the [trigger function that was created](https://github.com/NYCPlanning/labs-zap-api/blob/develop/migrations/1556561208255_add-transformed-geometry-columns.js) to create Web Mercator (SRID 3857) copies of the geoms was preventing new projects rows from being inserted into `project_geoms`. To solve this, @allthesignals and I deleted the finicky trigger functions. 

In this PR, I've added to the Carto SQL query to get Web Mercator (SRID 3857) geoms directly from Carto, instead of needing to create the transformed geoms in our database upon UPDATE/INSERT using a trigger function.

This PR also
- Fixes error logging for when the PSQL UPDATE/INSERT fails
- Adds the necessary USER API KEY variable to the update-geometries test. It had been failing because this was missing.

Addresses #144 